### PR TITLE
VisualHFSM pretty print

### DIFF
--- a/src/stable/components/visualHFSM/CMakeLists.txt
+++ b/src/stable/components/visualHFSM/CMakeLists.txt
@@ -46,4 +46,13 @@ TARGET_LINK_LIBRARIES ( visualHFSM
     ${libxmlpp_LIBRARIES}
 )
 
+
+add_custom_command(TARGET visualHFSM POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/gui $<TARGET_FILE_DIR:visualHFSM>/gui)
+
+add_custom_command(TARGET visualHFSM POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/getinterfaces.sh $<TARGET_FILE_DIR:visualHFSM>)
+add_custom_command(TARGET visualHFSM POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/allinterfaces.txt $<TARGET_FILE_DIR:visualHFSM>)
+
 ENDIF()

--- a/src/stable/components/visualHFSM/generate.cpp
+++ b/src/stable/components/visualHFSM/generate.cpp
@@ -1062,23 +1062,23 @@ void Generate::generaitJoin_py(){
 }
 
 void Generate::generateMain_py (){
-	this->fs << "if __name__ == '__main__':" << std::endl;
-	this->fs << std::endl;
-	this->fs << this->mapTab[T_ONE];
-	this->fs << "signal.signal(signal.SIGINT, signal.SIG_DFL)" << std::endl;
-	this->fs << this->mapTab[T_ONE] << "automata = Automata()" << std::endl;
-	this->fs << this->mapTab[T_ONE] << "try:" << std::endl;
-	this->fs << this->mapTab[T_TWO] << "automata.connectToProxys()" << std::endl;
+	this->fs <<
+"if __name__ == '__main__':\n\
+	signal.signal(signal.SIGINT, signal.SIG_DFL)\n\
+	automata = Automata()\n\
+	try:\n\
+		automata.connectToProxys()\n\
+";
 	//TODO more automatagui
 	this->fs.flush();
-	this->fs << this->mapTab[T_TWO] << "automata.start()" << std::endl;
-	this->fs << this->mapTab[T_TWO] << "automata.join()" << std::endl;
-	this->fs << std::endl;
-
-	this->fs << this->mapTab[T_TWO] << "sys.exit(0)" << std::endl;
-
-	this->fs << this->mapTab[T_ONE] << "except:" << std::endl;
-	this->fs << this->mapTab[T_TWO] << "traceback.print_exc()" <<std::endl;
-	this->fs << this->mapTab[T_TWO] << "automata.destroyIc()" << std::endl;
-	this->fs << this->mapTab[T_TWO] << "sys.exit(-1)"<< std::endl;
+	this->fs <<
+"		automata.start()\n\
+		automata.join()\n\
+		\n\
+		sys.exit(0)\n\
+	except:\n\
+		traceback.print_exc()\n\
+		automata.destroyIc()\n\
+		sys.exit(-1)\n\
+";
 }

--- a/src/stable/components/visualHFSM/generate.cpp
+++ b/src/stable/components/visualHFSM/generate.cpp
@@ -1005,28 +1005,25 @@ void Generate::generateSubautomatas_py(){
 }
 
 void Generate::generateConnectToProxys_py(){
-	this->fs << this->mapTab[T_ONE] << "def connectToProxys(self):" << std::endl;
-	this->fs << this->mapTab[T_TWO] << "self.ic = Ice.initialize(sys.argv)" << std::endl;
-	this->fs << std::endl;
+	this->fs << 
+"	def connectToProxys(self):\n\
+		self.ic = Ice.initialize(sys.argv)\n\
+\n";
+	boost::format fmt_iConnect( /* %1%: getName() %2%: getInterface() */
+"		# Contact to %1%\n\
+		%1% = self.ic.propertyToProxy('automata.%2%.Proxy')\n\
+		if(not %1%):\n\
+			raise Exception('could not create proxy with %1%')\n\
+		self.%1%Prx = %2%Prx.checkedCast(%1%)\n\
+		if(not self.%1%Prx):\n\
+			raise Exception('invalid proxy automata.%2%.Proxy')\n\
+		print '%1% connected'\n\
+\n");
 	for ( std::list<IceInterface>::iterator listInterfacesIterator = this->listInterfaces->begin();
 			listInterfacesIterator != this->listInterfaces->end(); listInterfacesIterator++ ) {
-		this->fs << this->mapTab[T_TWO];
-		this->fs << "# Contact to " << listInterfacesIterator->getName() << std::endl;
-		this->fs << this->mapTab[T_TWO];
-		this->fs << listInterfacesIterator->getName() << " = self.ic.propertyToProxy(\"automata." << listInterfacesIterator->getInterface() << ".Proxy\");" << std::endl;
-		this->fs << this->mapTab[T_TWO];
-		this->fs << "if(not " << listInterfacesIterator->getName() << "):" << std::endl;
-		this->fs << this->mapTab[T_THREE];
-		this->fs << "raise Exception(\"could not create proxy with" << listInterfacesIterator->getName() << "\")" << std::endl;
-		this->fs << this->mapTab[T_TWO];
-		this->fs << "self." << listInterfacesIterator->getName() << "Prx = " << listInterfacesIterator->getInterface() << "Prx.checkedCast(" << listInterfacesIterator->getName() << ")" << std::endl;
-		this->fs << this->mapTab[T_TWO];
-		this->fs << "if(not self." << listInterfacesIterator->getName() << "Prx):" << std::endl;
-		this->fs << this->mapTab[T_THREE];
-		this->fs << "raise Exception(\"invalid proxy automata." << listInterfacesIterator->getName() << ".Proxy\")" << std::endl;
-		this->fs << this->mapTab[T_TWO];
-		this->fs << "print \"" << listInterfacesIterator->getName() << " connected\"" << std::endl;
-		this->fs << std::endl;
+		std::string iName = listInterfacesIterator->getName();
+		std::string iInterface = listInterfacesIterator->getInterface();
+		std::cout<<boost::str(fmt_iConnect % iName % iInterface);
 	}
 	this->fs << std::endl;
 }

--- a/src/stable/components/visualHFSM/generate.h
+++ b/src/stable/components/visualHFSM/generate.h
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <algorithm>
+#include <boost/format.hpp>
 
 #include "subautomata.h"
 #include "iceinterface.h"


### PR DESCRIPTION
*This pull request should be at https://github.com/reysam93/JdeRobot, otherwise is invalid.*
*Related to https://github.com/RoboticsURJC/JdeRobot/issues/211*

Two examples for **\n\** and **boost::format** style-sheet.
*  generateMain_py
* generateConnectToProxys_py

Please, get further explanation here:
* http://studiofreya.com/cpp/a-few-boostformat-examples/
* https://gist.github.com/varhub/c002b6405db170eaee7c
* http://www.boost.org/doc/libs/1_59_0/libs/format/doc/format.html

Final note about **\n**
Since code relies on `getinterfaces.sh` and python interpreter fully supports **\n** on any platform, so there is no real drawback compared to std::endl

***This code is untested***